### PR TITLE
Update URLs and README style change

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 A minimal online application to interact with Discord webhooks easily
 
-<a href="https://webhook.yagiz.dev/">![Screenshot](https://i.imgur.com/hPx9o8i.png)</a>
+[![Screenshot](https://i.imgur.com/hPx9o8i.png)](https://webhook.yagiz.dev)
 
-<hr>
+***
 
-The application is reachable on [webhook.yagiz.dev](webhook.yagiz.dev), while it only has the ability to send simple messages for now, I'm planning to integrate more advanced use cases like file uploads, embeds, and possibly more. I used jQuery, Font Awesome and Bootstrap in this project.
+The application is reachable on [webhook.yagiz.dev](https://webhook.yagiz.dev). While it only has the ability to send simple messages for now, I'm planning to integrate more advanced use cases like file uploads, embeds, and possibly more. I used jQuery, Font Awesome and Bootstrap in this project.
 
 Feel free to create pull requests and issues, I'll check them. If you have any questions, reach me over [my socials](https://yagiz.dev) or [hi@yagiz.dev](mailto:hi@yagiz.dev).
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -63,7 +63,7 @@ $('#main-form').on('submit', function(e) {
         },
         success: displayMessage("success", "Successfully passed the message to the webhook."),
         error: function(xhr, status, error) {
-            displayMessage("danger", error || "An unexpected error occurred. You might want to check your browser's console output.<br />If you <a href='https://github.com/evrifaessa/discord-webhook/issues'>create an issue</a> about the error, it would be very helpful.");
+            displayMessage("danger", error || "An unexpected error occurred. You might want to check your browser's console output.<br />If you <a href='https://github.com/evrifaessa/discord-webhook/issues/new'>create an issue</a> about the error, it would be very helpful.");
         }
       });
 });

--- a/index.html
+++ b/index.html
@@ -27,20 +27,20 @@
     <link rel="manifest" href="./assets/favicon/site.webmanifest">
     <link rel="mask-icon" href="./assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
     <link rel="shortcut icon" href="./assets/favicon/favicon.ico">
-    <link rel="canonical" href="https://discord-webhook.js.org">
+    <link rel="canonical" href="https://webhook.yagiz.dev">
     
     <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://discord-webhook.js.org">
+    <meta property="og:url" content="https://webhook.yagiz.dev">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="discord-webhook.js.org">
+    <meta property="og:title" content="webhook.yagiz.dev">
     <meta property="og:description" content="A minimal online application to interact with Discord webhooks easily.">
     <meta property="og:image" content="https://raw.githubusercontent.com/evrifaessa/discord-webhook/master/assets/images/placeholder.png">
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="discord-webhook.js.org">
-    <meta property="twitter:url" content="https://discord-webhook.js.org">
-    <meta name="twitter:title" content="discord-webhook.js.org">
+    <meta property="twitter:domain" content="webhook.yagiz.dev">
+    <meta property="twitter:url" content="https://webhook.yagiz.dev">
+    <meta name="twitter:title" content="webhook.yagiz.dev">
     <meta name="twitter:description" content="A minimal online application to interact with Discord webhooks easily.">
     <meta name="twitter:image" content="https://raw.githubusercontent.com/evrifaessa/discord-webhook/master/assets/images/placeholder.png">
   </head>

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-Agent: *
 Allow: 
 
-Sitemap: https://discord-webhook.js.org/sitemap.xml
+Sitemap: https://webhook.yagiz.dev/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,8 +6,8 @@
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
 <url>
-  <loc>https://discord-webhook.js.org/</loc>
-  <lastmod>2020-12-21T08:44:15+00:00</lastmod>
+  <loc>https://webhook.yagiz.dev/</loc>
+  <lastmod>2022-08-03T15:21:06+00:00</lastmod>
 </url>
 
 </urlset>


### PR DESCRIPTION
I changed README style to Markdown-only (removed HTML tags and changed them to the equivalent Markdown ones). This is a personal preference, so feel free to undo it if you do not agree with it.

I also updated links, such as references to the previous URL, and altered the issue link to open directly to the new issue creation page. The last change was also a personal preference that you can (ask me to) change if you'd prefer redirection to issue view.

I don't think I've missed something, but if I did feel free to point it out.
***
A question: Is the choice to display the screenshot from an external provider (Imgur), instead of having it in the repository and displaying from there, intentional to not clutter the repository? I think that having the screenshot inside the repo is better so that any potential issues with external providers, such as downtimes, are avoided, but I understand it may be another unneccesary file addition.